### PR TITLE
Fix xregexp module loading

### DIFF
--- a/dist_node/lex/common.js
+++ b/dist_node/lex/common.js
@@ -3,7 +3,7 @@
  * DO NOT EDIT
 */
 "use strict";
-var XRP = require("XRegExp"),
+var XRP = require("xregexp"),
     __o = require("bennu")["parse"],
     __o0 = require("nu-stream")["stream"],
     join, match, map = __o["map"],

--- a/lib/lex/common.kep
+++ b/lib/lex/common.kep
@@ -5,7 +5,7 @@ package (
     join
     match)
 with
-    import 'XRegExp' XRP,
+    import 'xregexp' XRP,
     
     import 'bennu::parse' {
         map


### PR DESCRIPTION
In lib/lex/common.kep xregexp module was referenced as XRegExp,
which do not work when installed via npm on case-sensitive file system.
